### PR TITLE
fix contact/ broken link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,7 +20,7 @@
           on platforms like HTB and Root-Me.
         </p>
         <p>
-          <a href="/contact/"
+          <a href="mailto:huynhjeanpierre@hotmail.com"
             hx-target="main"
             hx-select="main"
             hx-swap="outerHTML">


### PR DESCRIPTION
the contact/ href on the home page doesn't lead us anywhere, here it is fixed by adding your email instead